### PR TITLE
Check to make sure that guest renaming doesn't overwrite existing users.

### DIFF
--- a/frontend/src/components/schedule_overlap/ScheduleOverlap.vue
+++ b/frontend/src/components/schedule_overlap/ScheduleOverlap.vue
@@ -3468,7 +3468,8 @@ export default {
         this.$emit("setCurGuestId", newName)
         this.refreshEvent()
       } catch (err) {
-        this.showError(err.message || "Failed to update guest name")
+        const errorMessage = err.parsed?.error || err.message || "Failed to update guest name"
+        this.showError(errorMessage)
       }
     },
     refreshEvent() {


### PR DESCRIPTION
Closes #201 

# Frontend edits:
`saveGuestName()` function in `frontend/src/components/schedule_overlap/ScheduleOverlap.vue` now handles error messages from the `/events/{eventId}/rename-user` endpoint more gracefully by correctly accessing the error message from the parsed response (`err.parsed?.error`).

# Backend edits:

`server/db/events.go`:
- `GuestNameExists` function checks for:
  - Duplicate guest names
  - Names that match logged-in user ObjectIDs

NOTE: we check for logged-in user ObjectIDs even for logged-in users who have not submitted availability BECAUSE if they were to submit availability then conflicts would happen, and the only thing we're losing by preventing this is the user being unable to change their name to a HIGHLY specific hex username (and if they're doing this they're probably trying to be malicious anyways).

`server/routes/events.go`:
- The `/events/{eventId}/rename-user` endpoint now validates guest name existence by calling the `GuestNameExists` function before renaming.