### PR TITLE
[FIX] Better cookies security

### DIFF
--- a/server/.env.template
+++ b/server/.env.template
@@ -45,3 +45,8 @@ SCHEJ_EMAIL_ADDRESS=? # optional
 
 # Encryption
 ENCRYPTION_KEY=? # Used to encrypt and decrypt sensitive data
+
+# Session
+# - Generate a random 32+ character string for session cookie encryption
+# - Example generation: openssl rand -base64 32
+SESSION_SECRET=?

--- a/server/main.go
+++ b/server/main.go
@@ -105,7 +105,7 @@ func main() {
 	defer closeTasks()
 
 	// Session
-	store := cookie.NewStore([]byte("secret"))
+	store := cookie.NewStore([]byte(os.Getenv("SESSION_SECRET")))
 	router.Use(sessions.Sessions("session", store))
 
 	// Init routes
@@ -143,12 +143,28 @@ func main() {
 // Load .env variables
 func loadDotEnv() {
 	err := godotenv.Load(".env")
+	if err != nil {
+		logger.StdErr.Panicln("Error loading .env file")
+	}
 
 	// Load stripe key
 	stripe.Key = os.Getenv("STRIPE_API_KEY")
 
-	if err != nil {
-		logger.StdErr.Panicln("Error loading .env file")
+	// Validate session secret
+	validateSessionSecret()
+}
+
+// validateSessionSecret ensures SESSION_SECRET is set and meets security requirements
+func validateSessionSecret() {
+	secret := os.Getenv("SESSION_SECRET")
+
+	if secret == "" {
+		logger.StdErr.Panicln("SESSION_SECRET environment variable is required but not set")
+	}
+
+	// Minimum 32 characters for adequate security (256 bits)
+	if len(secret) < 32 {
+		logger.StdErr.Panicln("SESSION_SECRET must be at least 32 characters long")
 	}
 }
 


### PR DESCRIPTION
  **Problem**
  The session store was initialized with a hardcoded literal string "secret":
  store := cookie.NewStore([]byte("secret"))

  **Solution**
  - Session secret is now loaded from `SESSION_SECRET` environment variable
  - Server validates the secret exists and is at least 32 characters at startup
  - Server refuses to start if misconfigured (fail-fast)