### PR TITLE
Fix timezone auto-detection for DST-observing regions

### DIFF
--- a/frontend/src/components/schedule_overlap/TimezoneSelector.vue
+++ b/frontend/src/components/schedule_overlap/TimezoneSelector.vue
@@ -43,6 +43,11 @@
 <script>
 import { allTimezones } from "@/constants"
 import spacetime from "spacetime"
+import dayjs from "dayjs"
+import utcPlugin from "dayjs/plugin/utc"
+import timezonePlugin from "dayjs/plugin/timezone"
+dayjs.extend(utcPlugin)
+dayjs.extend(timezonePlugin)
 
 export default {
   name: "TimezoneSelector",
@@ -123,13 +128,31 @@ export default {
     /** Returns a timezone object for the local timezone */
     getLocalTimezone() {
       const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+      // Step 1: Exact match on spacetime-canonical name
       let timezoneObject = this.timezones.find((t) => t.value === localTimezone)
 
       if (!timezoneObject) {
+        // Step 2: Match by offsets at two reference dates (Jan + Jul)
+        // Distinguishes DST-observing zones from non-DST zones that share
+        // the same current offset (e.g. Europe/Belgrade vs Africa/Casablanca)
+        const janOffset = dayjs.tz("2024-01-15 12:00", localTimezone).utcOffset()
+        const julOffset = dayjs.tz("2024-07-15 12:00", localTimezone).utcOffset()
+
+        timezoneObject = this.timezones.find((t) => {
+          const tJan = dayjs.tz("2024-01-15 12:00", t.value).utcOffset()
+          const tJul = dayjs.tz("2024-07-15 12:00", t.value).utcOffset()
+          return tJan === janOffset && tJul === julOffset
+        })
+      }
+
+      if (!timezoneObject) {
+        // Step 3: Final fallback — current offset only
         const offset =
           spacetime.now(localTimezone).timezone().current.offset * 60
         timezoneObject = this.timezones.find((t) => t.offset === offset)
       }
+
       return timezoneObject
     },
     /** Resets timezone to the local timezone and clears localstorage as well */


### PR DESCRIPTION
## Summary

Fixes #136

When opening an event link in a private/anonymous browser window, the timezone auto-detection picks `Africa/Casablanca` (GMT+1, no DST) instead of the correct European timezone like `Europe/Belgrade` (which covers Prague, Bratislava, Budapest, Ljubljana). This causes availability slots to shift by 1 hour for events with dates during DST periods.

**Root cause:** `getLocalTimezone()` in `TimezoneSelector.vue` tries to match the browser's IANA timezone (e.g. `Europe/Prague`) against the spacetime-canonical `value` field. Since spacetime canonicalizes `Europe/Prague` → `Europe/Belgrade`, the exact match fails. The fallback uses `.find()` on current UTC offset only — in winter, both Casablanca and Belgrade have offset +60, and Casablanca appears first in the sorted array.

**Fix:** Add a DST-aware intermediate matching step that compares UTC offsets at two reference dates (January 15 and July 15). This distinguishes timezones that observe DST from those that don't:

| Timezone | Jan offset | Jul offset |
|---|---|---|
| `Europe/Prague` (browser) | +60 | +120 |
| `Europe/Belgrade` (list entry) | +60 | +120 ✅ |
| `Africa/Casablanca` (list entry) | +60 | +60 ❌ |

The matching now has 3 steps:
1. **Exact match** on spacetime-canonical name (unchanged)
2. **Dual-offset match** — compare Jan + Jul offsets using `dayjs` (new)
3. **Current offset fallback** (unchanged, last resort)

`dayjs` with timezone plugin is already a project dependency, used in `ScheduleOverlap.vue`, `NewEvent.vue`, `date_utils.js`, etc.

## Test plan

- [ ] Override browser timezone to `Europe/Prague` → should show "Belgrade, Bratislava, Budapest, Ljubljana, Prague" (not Casablanca)
- [ ] Override to `Europe/Berlin` → should show "Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
- [ ] Override to `Africa/Casablanca` → should still show "Casablanca, Monrovia"
- [ ] Override to `America/New_York` → should show "Eastern Time" (exact match, unchanged)
- [ ] Override to `Australia/Sydney` → should show "Canberra, Melbourne, Sydney"
- [ ] Create a specific-dates event with summer dates, open in private window with Prague timezone — verify no 1-hour shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)