### PR TITLE
Stop GCloud initilization early if service account key var not found

### DIFF
--- a/server/services/gcloud/tasks.go
+++ b/server/services/gcloud/tasks.go
@@ -43,6 +43,11 @@ func InitTasks() func() {
 }
 
 func CreateEmailTask(email string, ownerName string, eventName string, eventId string) []string {
+	if TasksClient == nil {
+		logger.StdErr.Println("WARNING: Cloud Tasks is disabled, skipping CreateEmailTask")
+		return []string{}
+	}
+
 	// Get listmonk url env vars
 	listmonkUrl := os.Getenv("LISTMONK_URL")
 	listmonkUsername := os.Getenv("LISTMONK_USERNAME")
@@ -131,6 +136,11 @@ func CreateEmailTask(email string, ownerName string, eventName string, eventId s
 }
 
 func DeleteEmailTask(taskId string) {
+	if TasksClient == nil {
+		logger.StdErr.Println("WARNING: Cloud Tasks is disabled, skipping DeleteEmailTask")
+		return
+	}
+
 	err := TasksClient.DeleteTask(context.Background(), &cloudtaskspb.DeleteTaskRequest{
 		Name: taskId,
 	})

--- a/server/services/gcloud/tasks.go
+++ b/server/services/gcloud/tasks.go
@@ -22,11 +22,15 @@ import (
 var TasksClient *cloudtasks.Client
 
 func InitTasks() func() {
+	credsFile := os.Getenv("SERVICE_ACCOUNT_KEY_PATH")
+	if credsFile == "" || credsFile == "?" {
+		logger.StdErr.Println("SERVICE_ACCOUNT_KEY_PATH not set, skipping Cloud Tasks initialization")
+		return func() {}
+	}
+
 	ctx := context.Background()
 
 	var err error
-	credsFile := os.Getenv("SERVICE_ACCOUNT_KEY_PATH")
-
 	TasksClient, err = cloudtasks.NewClient(ctx, option.WithCredentialsFile(credsFile))
 	if err != nil {
 		logger.StdErr.Panicln(err)


### PR DESCRIPTION
This PR makes it so the GCloud initialization will return/end cleanly if the `SERVICE_ACCOUNT_KEY_PATH` env var is not set. 

The env var isn't required as Timeful can be used without an account. Making this optional simplifies local dev setup.