### PR TITLE
fix(settings): align My calendars spacing

### DIFF
--- a/frontend/src/components/settings/CalendarAccounts.vue
+++ b/frontend/src/components/settings/CalendarAccounts.vue
@@ -43,37 +43,42 @@
             "
             @openRemoveDialog="openRemoveDialog"
           ></CalendarAccount>
+          <v-dialog
+            v-if="allowAddCalendarAccount"
+            v-model="addCalendarAccountDialog"
+            width="400"
+            content-class="tw-m-0"
+          >
+            <template v-slot:activator="{ on, attrs }">
+              <div>
+                <v-btn
+                  text
+                  color="primary"
+                  :class="
+                    toggleState
+                      ? '-tw-ml-2 tw-mt-0 tw-w-min tw-px-2'
+                      : '-tw-ml-2 tw-w-fit tw-px-2'
+                  "
+                  v-bind="attrs"
+                  v-on="on"
+                  >+ Add calendar</v-btn
+                >
+                <p class="tw-mb-0 tw-mt-1 tw-text-xs tw-text-dark-gray">
+                  Only your available times are shared with respondents. Your
+                  personal event details are never shared.
+                </p>
+              </div>
+            </template>
+            <CalendarTypeSelector
+              :visible="addCalendarAccountDialog"
+              @addGoogleCalendar="addGoogleCalendar"
+              @addOutlookCalendar="addOutlookCalendar"
+              @addedCalendar="addedCalendar"
+            />
+          </v-dialog>
         </div>
       </span>
     </v-expand-transition>
-    <v-dialog
-      v-if="allowAddCalendarAccount && (showCalendars || !toggleState)"
-      v-model="addCalendarAccountDialog"
-      width="400"
-      content-class="tw-m-0"
-    >
-      <template v-slot:activator="{ on, attrs }">
-        <div>
-          <v-btn
-            text
-            color="primary"
-            :class="
-              toggleState ? '-tw-ml-2 tw-mt-0 tw-w-min tw-px-2' : 'tw-w-full'
-            "
-            v-bind="attrs"
-            v-on="on"
-            >+ Add calendar</v-btn
-          >
-          <p class="tw-text-xs tw-text-dark-gray">Only your available times are shared with respondents. Your personal event details are never shared.</p>
-        </div>
-      </template>
-      <CalendarTypeSelector
-        :visible="addCalendarAccountDialog"
-        @addGoogleCalendar="addGoogleCalendar"
-        @addOutlookCalendar="addOutlookCalendar"
-        @addedCalendar="addedCalendar"
-      />
-    </v-dialog>
     <v-dialog v-model="removeDialog" width="500" persistent>
       <v-card>
         <v-card-title>Are you sure?</v-card-title>


### PR DESCRIPTION
## Summary
- Move the **Add calendar** `<v-dialog>` back inside the `tw-px-4 tw-py-2` wrapper so the button and disclaimer share the same indent as the account row
- Switch the button from `tw-w-full` (which centered the label awkwardly) to `-tw-ml-2 tw-w-fit tw-px-2` so it left-aligns under the account row
- Zero out the default browser `<p>` margins and use `tw-mt-1` so the disclaimer sits tightly below the button

Closes the weird vertical gap between the calendar account and the Add calendar button in the Settings → Calendar access section, and the disclaimer no longer runs flush against the card's left edge.

## Test plan
- [ ] Settings page: My calendars card shows the account, the `+ Add calendar` button, and the disclaimer all aligned under the same left padding, with tight vertical spacing
- [ ] Clicking `+ Add calendar` still opens the CalendarTypeSelector dialog
- [ ] Toggle-state consumers (InvitationDialog, ScheduleOverlap) still render the collapse chevron and fit-width button as before