### PR TITLE
Fix Go test hygiene

### DIFF
--- a/server/db/db_test.go
+++ b/server/db/db_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -10,11 +11,22 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+func requireIntegrationTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv("RUN_INTEGRATION_TESTS") != "1" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run MongoDB integration tests")
+	}
+}
+
 func TestGetDailyUserLogByDate(t *testing.T) {
+	requireIntegrationTests(t)
+	db.Init()
+
 	db.GetDailyUserLogByDate(time.Now(), 7)
 }
 
 func TestGenerateShortEventId(t *testing.T) {
+	requireIntegrationTests(t)
 	db.Init()
 
 	objectId, _ := primitive.ObjectIDFromHex("6607d6409f96021811c0a55f")

--- a/server/scripts/20230812_add_calendar_accounts/main.go
+++ b/server/scripts/20230812_add_calendar_accounts/main.go
@@ -1,3 +1,5 @@
+//go:build migration
+
 package main
 
 import (

--- a/server/scripts/20230914_15_minute_increments/main.go
+++ b/server/scripts/20230914_15_minute_increments/main.go
@@ -1,3 +1,5 @@
+//go:build migration
+
 package main
 
 import (

--- a/server/scripts/20240909_multiple_calendar_support_groups/main.go
+++ b/server/scripts/20240909_multiple_calendar_support_groups/main.go
@@ -1,3 +1,5 @@
+//go:build migration
+
 package main
 
 import (

--- a/server/services/gcloud/tasks_test.go
+++ b/server/services/gcloud/tasks_test.go
@@ -11,7 +11,16 @@ import (
 	"schej.it/server/logger"
 )
 
+func requireIntegrationTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv("RUN_INTEGRATION_TESTS") != "1" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run Cloud Tasks integration tests")
+	}
+}
+
 func TestCreateEmailTask(t *testing.T) {
+	requireIntegrationTests(t)
+
 	// Init logfile
 	logFile, err := os.OpenFile("logs.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -32,6 +41,8 @@ func TestCreateEmailTask(t *testing.T) {
 }
 
 func TestDeleteEmailTask(t *testing.T) {
+	requireIntegrationTests(t)
+
 	// Init logfile
 	logFile, err := os.OpenFile("logs.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {

--- a/server/services/listmonk/listmonk_test.go
+++ b/server/services/listmonk/listmonk_test.go
@@ -10,7 +10,16 @@ import (
 	"schej.it/server/logger"
 )
 
+func requireIntegrationTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv("RUN_INTEGRATION_TESTS") != "1" {
+		t.Skip("set RUN_INTEGRATION_TESTS=1 to run Listmonk integration tests")
+	}
+}
+
 func TestSendEmail(t *testing.T) {
+	requireIntegrationTests(t)
+
 	// Init logfile
 	logFile, err := os.OpenFile("logs.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {


### PR DESCRIPTION
## Summary\n- keep stale one-off migration commands out of default Go package builds with a migration build tag\n- skip live MongoDB, Cloud Tasks, and Listmonk integration tests unless RUN_INTEGRATION_TESTS=1 is set\n\n## Verification\n- go test ./...\n- go vet ./...\n- npm run test:unit\n- npm run build