### PR TITLE
Harden calendar provider parsing

### DIFF
--- a/server/services/calendar/apple_calendar.go
+++ b/server/services/calendar/apple_calendar.go
@@ -74,6 +74,7 @@ func (calendar *AppleCalendar) GetCalendarEvents(calendarId string, timeMin time
 					"DTSTART",
 					"DTEND",
 					"DURATION",
+					"TRANSP",
 				},
 			}},
 			Expand: &caldav.CalendarExpandRequest{
@@ -96,7 +97,17 @@ func (calendar *AppleCalendar) GetCalendarEvents(calendarId string, timeMin time
 
 	var filteredEvents []models.CalendarEvent
 	for _, event := range events {
-		startTimeString := event.Data.Children[0].Props["DTSTART"][0].Value
+		if len(event.Data.Children) == 0 {
+			continue
+		}
+		eventProps := event.Data.Children[0].Props
+		dtStart := eventProps.Get("DTSTART")
+		dtEnd := eventProps.Get("DTEND")
+		if dtStart == nil || dtEnd == nil {
+			continue
+		}
+
+		startTimeString := dtStart.Value
 		allDay := false
 
 		var startTime time.Time
@@ -104,27 +115,47 @@ func (calendar *AppleCalendar) GetCalendarEvents(calendarId string, timeMin time
 
 		if !strings.Contains(startTimeString, "T") {
 			// Handle all day events
-			startTime, _ = time.Parse("20060102", startTimeString)
-			endTime, _ = time.Parse("20060102", event.Data.Children[0].Props["DTEND"][0].Value)
-			allDay = true
-		} else {
-			// Handle normal events
-			startTime, err = parseTimeWithTZ(event.Data.Children[0].Props.Get("DTSTART"))
+			startTime, err = time.Parse("20060102", startTimeString)
 			if err != nil {
 				continue
 			}
-			endTime, err = parseTimeWithTZ(event.Data.Children[0].Props.Get("DTEND"))
+			endTime, err = time.Parse("20060102", dtEnd.Value)
+			if err != nil {
+				continue
+			}
+			allDay = true
+		} else {
+			// Handle normal events
+			startTime, err = parseTimeWithTZ(dtStart)
+			if err != nil {
+				continue
+			}
+			endTime, err = parseTimeWithTZ(dtEnd)
 			if err != nil {
 				continue
 			}
 		}
 
+		uid := ""
+		if uidProp := eventProps.Get("UID"); uidProp != nil {
+			uid = uidProp.Value
+		}
+		summary := ""
+		if summaryProp := eventProps.Get("SUMMARY"); summaryProp != nil {
+			summary = summaryProp.Value
+		}
+		free := false
+		if transparency := eventProps.Get(ical.PropTransparency); transparency != nil {
+			free = strings.EqualFold(transparency.Value, "TRANSPARENT")
+		}
+
 		filteredEvents = append(filteredEvents, models.CalendarEvent{
-			Id:         event.Data.Children[0].Props.Get("UID").Value,
+			Id:         uid,
 			CalendarId: calendarId,
-			Summary:    event.Data.Children[0].Props.Get("SUMMARY").Value,
+			Summary:    summary,
 			StartDate:  primitive.NewDateTimeFromTime(startTime),
 			EndDate:    primitive.NewDateTimeFromTime(endTime),
+			Free:       free,
 			AllDay:     allDay,
 		})
 	}
@@ -154,6 +185,10 @@ func (calendar *AppleCalendar) getClients() (*webdav.Client, *caldav.Client, err
 }
 
 func parseTimeWithTZ(prop *ical.Prop) (time.Time, error) {
+	if prop == nil {
+		return time.Time{}, fmt.Errorf("missing datetime property")
+	}
+
 	timeStr := prop.Value
 	tzID := prop.Params.Get("TZID")
 

--- a/server/services/calendar/calendar.go
+++ b/server/services/calendar/calendar.go
@@ -1,12 +1,23 @@
 package calendar
 
 import (
+	"fmt"
 	"time"
 
 	"schej.it/server/models"
 	"schej.it/server/services/auth"
 	"schej.it/server/utils"
 )
+
+func panicToError(err interface{}) error {
+	if err == nil {
+		return nil
+	}
+	if e, ok := err.(error); ok {
+		return e
+	}
+	return fmt.Errorf("%v", err)
+}
 
 type GetCalendarListData struct {
 	CalendarList       map[string]models.SubCalendar `json:"calendarList"`
@@ -19,7 +30,7 @@ func GetCalendarListAsync(calendarAccountKey string, calendarProvider *CalendarP
 	// Recover from panics
 	defer func() {
 		if err := recover(); err != nil {
-			c <- GetCalendarListData{Error: err.(error)}
+			c <- GetCalendarListData{Error: panicToError(err)}
 		}
 	}()
 
@@ -39,7 +50,7 @@ func GetCalendarEventsAsync(calendarAccountKey string, calendarProvider *Calenda
 	// Recover from panics
 	defer func() {
 		if err := recover(); err != nil {
-			c <- GetCalendarEventsData{Error: err.(error)}
+			c <- GetCalendarEventsData{Error: panicToError(err)}
 		}
 	}()
 
@@ -69,6 +80,9 @@ func GetUsersCalendarEvents(user *models.User, accounts models.Set[string], time
 	numCalendarListRequests := 0
 	for _, account := range user.CalendarAccounts {
 		calendarProvider := GetCalendarProvider(account)
+		if calendarProvider == nil {
+			continue
+		}
 		calendarAccountKey := utils.GetCalendarAccountKey(account.Email, account.CalendarType)
 
 		// Get secondary account calendars
@@ -99,6 +113,9 @@ func GetUsersCalendarEvents(user *models.User, accounts models.Set[string], time
 		// Edit subcalendars map
 		account := user.CalendarAccounts[calendarListData.CalendarAccountKey]
 		calendarProvider := GetCalendarProvider(account)
+		if calendarProvider == nil {
+			continue
+		}
 		if account.SubCalendars == nil {
 			account.SubCalendars = &calendarListData.CalendarList
 			user.CalendarAccounts[calendarListData.CalendarAccountKey] = account

--- a/server/services/calendar/calendar_test.go
+++ b/server/services/calendar/calendar_test.go
@@ -1,0 +1,43 @@
+package calendar
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/emersion/go-ical"
+)
+
+func TestPanicToErrorPreservesErrors(t *testing.T) {
+	expected := errors.New("calendar failed")
+
+	if got := panicToError(expected); got != expected {
+		t.Fatalf("panicToError() = %v, want original error", got)
+	}
+}
+
+func TestPanicToErrorConvertsStrings(t *testing.T) {
+	got := panicToError("calendar failed")
+	if got == nil || got.Error() != "calendar failed" {
+		t.Fatalf("panicToError() = %v, want string converted to error", got)
+	}
+}
+
+func TestParseTimeWithTZRejectsMissingProperty(t *testing.T) {
+	if _, err := parseTimeWithTZ(nil); err == nil {
+		t.Fatal("parseTimeWithTZ(nil) succeeded, want error")
+	}
+}
+
+func TestParseTimeWithTZParsesTimezone(t *testing.T) {
+	got, err := parseTimeWithTZ(&ical.Prop{
+		Value:  "20260507T090000Z",
+		Params: ical.Params{},
+	})
+	if err != nil {
+		t.Fatalf("parseTimeWithTZ() returned error: %v", err)
+	}
+
+	if got.UTC().Format("2006-01-02T15:04:05Z") != "2026-05-07T09:00:00Z" {
+		t.Fatalf("parseTimeWithTZ() = %s, want UTC timestamp", got.UTC())
+	}
+}

--- a/server/services/calendar/google_calendar.go
+++ b/server/services/calendar/google_calendar.go
@@ -9,7 +9,6 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"schej.it/server/errs"
-	"schej.it/server/logger"
 	"schej.it/server/models"
 	"schej.it/server/utils"
 )
@@ -27,7 +26,7 @@ func (calendar GoogleCalendar) GetCalendarList() (map[string]models.SubCalendar,
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", calendar.AccessToken))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logger.StdErr.Panicln(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
@@ -44,7 +43,7 @@ func (calendar GoogleCalendar) GetCalendarList() (map[string]models.SubCalendar,
 	// Parse the response
 	var res Response
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		logger.StdErr.Panicln(err)
+		return nil, err
 	}
 
 	// Check if the response returned an error
@@ -82,7 +81,7 @@ func (calendar *GoogleCalendar) GetCalendarEvents(calendarId string, timeMin tim
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", calendar.AccessToken))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logger.StdErr.Panicln(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
@@ -112,7 +111,7 @@ func (calendar *GoogleCalendar) GetCalendarEvents(calendarId string, timeMin tim
 	// Parse the response
 	var res Response
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		logger.StdErr.Panicln(err)
+		return nil, err
 	}
 
 	// Check if the response returned an error
@@ -129,8 +128,14 @@ func (calendar *GoogleCalendar) GetCalendarEvents(calendarId string, timeMin tim
 
 		// Handle all day events
 		if item.Start.DateTime.IsZero() {
-			startDate, _ = time.Parse(time.DateOnly, item.Start.Date)
-			endDate, _ = time.Parse(time.DateOnly, item.End.Date)
+			startDate, err = time.Parse(time.DateOnly, item.Start.Date)
+			if err != nil {
+				continue
+			}
+			endDate, err = time.Parse(time.DateOnly, item.End.Date)
+			if err != nil {
+				continue
+			}
 			allDay = true
 		}
 

--- a/server/services/calendar/ics_calendar.go
+++ b/server/services/calendar/ics_calendar.go
@@ -66,8 +66,14 @@ func (cal *ICSCalendar) GetCalendarEvents(calendarId string, timeMin time.Time, 
 
 		// Check that event is not all day
 		if !strings.Contains(dtStart.Value, "T") {
-			startTime, _ = time.Parse("20060102", dtStart.Value)
-			endTime, _ = time.Parse("20060102", dtEnd.Value)
+			startTime, err = time.Parse("20060102", dtStart.Value)
+			if err != nil {
+				continue
+			}
+			endTime, err = time.Parse("20060102", dtEnd.Value)
+			if err != nil {
+				continue
+			}
 			allDay = true
 		} else {
 			startTime, err = parseTimeWithTZ(dtStart)


### PR DESCRIPTION
## Summary\n- convert recovered calendar panics into normal errors even when providers panic with strings\n- avoid panics on malformed or incomplete Apple/ICS/Google calendar events\n- add unit coverage for panic conversion and datetime parsing guardrails\n\n## Verification\n- go test ./...\n- go vet ./...