### PR TITLE
Update PostCSS security patch

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,7 @@
         "@vue/cli-plugin-vuex": "~5.0.0",
         "@vue/cli-service": "~5.0.8",
         "autoprefixer": "^10.4.17",
-        "postcss": "^8.4.33",
+        "postcss": "^8.5.14",
         "prettier": "^2.8.8",
         "prettier-plugin-tailwindcss": "^0.3.0",
         "sass": "~1.32.0",
@@ -9461,9 +9461,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "@vue/cli-plugin-vuex": "~5.0.0",
     "@vue/cli-service": "~5.0.8",
     "autoprefixer": "^10.4.17",
-    "postcss": "^8.4.33",
+    "postcss": "^8.5.14",
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.3.0",
     "sass": "~1.32.0",


### PR DESCRIPTION
## Summary\n- bump PostCSS to 8.5.14 to clear the fixable production audit advisory\n- leave the remaining Vue/Vuetify-family advisories untouched because npm reports they require semver-major framework upgrades\n\n## Verification\n- npm audit --omit=dev --json (PostCSS advisory removed; remaining 5 advisories require major upgrades)\n- npm run test:unit\n- npm run build