### PR TITLE
fix(auth): harden session cookie (HttpOnly/Secure/SameSite)

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -123,6 +123,21 @@ func main() {
 
 	// Session
 	store := cookie.NewStore([]byte(os.Getenv("SESSION_SECRET")))
+	// Harden the session cookie. Without these flags the gorilla cookie store
+	// defaults leave the session cookie readable by JavaScript (no HttpOnly),
+	// sendable over plain HTTP (no Secure), and with no explicit SameSite,
+	// making session theft via XSS and CSRF much easier.
+	//   - HttpOnly: keep the cookie out of reach of page JavaScript.
+	//   - Secure: only send over HTTPS in production (left off in dev so
+	//     http://localhost still works).
+	//   - SameSite=Lax: mitigate CSRF while still allowing top-level navigations.
+	store.Options(sessions.Options{
+		Path:     "/",
+		MaxAge:   60 * 60 * 24 * 30, // 30 days
+		HttpOnly: true,
+		Secure:   utils.IsRelease(),
+		SameSite: http.SameSiteLaxMode,
+	})
 	router.Use(sessions.Sessions("session", store))
 
 	// Init routes


### PR DESCRIPTION
## Severity: 🟠 High — session theft via XSS / insecure transport

> Stacked on #257. Review/merge that first; this PR targets its branch so the diff shows only the cookie change.

### The problem
The session is a signed cookie (`cookie.NewStore`), but no options were ever set on the store. The underlying gorilla defaults leave **all** security flags off, so the `session` cookie was:

- **No `HttpOnly`** → readable by page JavaScript; any XSS or malicious script can steal the session and impersonate the user.
- **No `Secure`** → sent over plain HTTP; vulnerable to interception / SSL-strip.
- **No explicit `SameSite`** → weaker CSRF posture than necessary.

### The fix
```go
store.Options(sessions.Options{
    Path:     "/",
    MaxAge:   60 * 60 * 24 * 30,
    HttpOnly: true,
    Secure:   utils.IsRelease(), // HTTPS-only in prod, off for localhost dev
    SameSite: http.SameSiteLaxMode,
})
```

`Secure` is gated on `utils.IsRelease()` so local development over `http://localhost:8080` keeps working, while production (same-origin HTTPS) gets the hardened cookie. `SameSite=Lax` is safe for the same-origin production setup and the same-site localhost dev setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)