### PR TITLE
fix(security): block SSRF via user-supplied ICS feed URLs

### DIFF
--- a/server/services/calendar/ics_calendar.go
+++ b/server/services/calendar/ics_calendar.go
@@ -26,8 +26,10 @@ func (cal *ICSCalendar) GetCalendarList() (map[string]models.SubCalendar, error)
 }
 
 func (cal *ICSCalendar) GetCalendarEvents(calendarId string, timeMin time.Time, timeMax time.Time) ([]models.CalendarEvent, error) {
-	// Fetch the data and ensure the fetch was successful
-	resp, err := http.Get(cal.FeedURL)
+	// Fetch the data and ensure the fetch was successful. The feed URL is
+	// user-supplied, so we use the SSRF-safe client (see safe_http.go) to keep
+	// the request from reaching internal/metadata addresses.
+	resp, err := safeGet(cal.FeedURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch ICS feed: %v", err)
 	}

--- a/server/services/calendar/safe_http.go
+++ b/server/services/calendar/safe_http.go
@@ -1,0 +1,80 @@
+package calendar
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"syscall"
+	"time"
+)
+
+// ssrfSafeClient is an HTTP client used to fetch user-supplied URLs (e.g. ICS
+// calendar feeds). Its dialer rejects connections to non-public IP addresses,
+// which prevents Server-Side Request Forgery (SSRF) — a user could otherwise
+// point a feed URL at internal services or the cloud metadata endpoint
+// (169.254.169.254) and have the server fetch them on their behalf.
+//
+// The check runs inside the dialer's Control hook, which fires *after* DNS
+// resolution with the concrete address about to be dialed. That means it also
+// defends against DNS-rebinding, where a hostname resolves to a public IP at
+// validation time and a private IP at fetch time, and it re-runs on every
+// redirect hop.
+var ssrfSafeClient = &http.Client{
+	Timeout: 15 * time.Second,
+	Transport: &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 10 * time.Second,
+			Control: func(network, address string, _ syscall.RawConn) error {
+				host, _, err := net.SplitHostPort(address)
+				if err != nil {
+					return err
+				}
+				ip := net.ParseIP(host)
+				if ip == nil {
+					return fmt.Errorf("could not parse IP from address %q", address)
+				}
+				if isDisallowedIP(ip) {
+					return fmt.Errorf("refusing to connect to non-public address %s", ip)
+				}
+				return nil
+			},
+		}).DialContext,
+	},
+}
+
+// isDisallowedIP reports whether the given IP is one we must never let a
+// user-supplied URL reach (loopback, private, link-local, metadata, etc.).
+func isDisallowedIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
+		return true
+	}
+	// Carrier-grade NAT range (100.64.0.0/10) is not covered by IsPrivate.
+	if ip4 := ip.To4(); ip4 != nil {
+		if ip4[0] == 100 && ip4[1]&0xc0 == 64 {
+			return true
+		}
+	}
+	return false
+}
+
+// safeGet performs an HTTP GET against a user-supplied URL while guarding
+// against SSRF. Only http/https URLs are allowed, and the connection is
+// refused if the host resolves to a non-public address.
+func safeGet(rawURL string) (*http.Response, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return ssrfSafeClient.Do(req)
+}

--- a/server/services/calendar/safe_http_test.go
+++ b/server/services/calendar/safe_http_test.go
@@ -1,0 +1,59 @@
+package calendar
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsDisallowedIP(t *testing.T) {
+	cases := []struct {
+		ip         string
+		disallowed bool
+	}{
+		// Public addresses should be allowed.
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"93.184.216.34", false}, // example.com
+		{"2606:2800:220:1:248:1893:25c8:1946", false},
+
+		// Loopback.
+		{"127.0.0.1", true},
+		{"::1", true},
+		// Private ranges.
+		{"10.0.0.1", true},
+		{"172.16.5.4", true},
+		{"192.168.1.1", true},
+		{"fd00::1", true},
+		// Link-local (includes the cloud metadata endpoint).
+		{"169.254.169.254", true},
+		{"fe80::1", true},
+		// Unspecified.
+		{"0.0.0.0", true},
+		{"::", true},
+		// Carrier-grade NAT.
+		{"100.64.0.1", true},
+		{"100.127.255.255", true},
+	}
+
+	for _, tc := range cases {
+		ip := net.ParseIP(tc.ip)
+		if ip == nil {
+			t.Fatalf("failed to parse test IP %q", tc.ip)
+		}
+		if got := isDisallowedIP(ip); got != tc.disallowed {
+			t.Errorf("isDisallowedIP(%s) = %v, want %v", tc.ip, got, tc.disallowed)
+		}
+	}
+}
+
+func TestSafeGetRejectsNonHTTPSchemes(t *testing.T) {
+	for _, rawURL := range []string{
+		"file:///etc/passwd",
+		"gopher://127.0.0.1:11211",
+		"ftp://example.com/resource",
+	} {
+		if _, err := safeGet(rawURL); err == nil {
+			t.Errorf("safeGet(%q) = nil error, want error for disallowed scheme", rawURL)
+		}
+	}
+}


### PR DESCRIPTION
## Severity: 🟡 Medium — authenticated SSRF

> Stacked on #258 (→ #257). Targets that branch so the diff is scoped to the SSRF fix.

### The problem
`/user/add-ics-calendar-account` stores an arbitrary user-supplied `feedUrl`, and `ICSCalendar.GetCalendarEvents` later fetched it with:

```go
resp, err := http.Get(cal.FeedURL)
```

The URL is fully attacker-controlled, giving any signed-in user an SSRF primitive. They can make the server fetch:
- the cloud metadata endpoint `http://169.254.169.254/…` (instance credential theft),
- internal-only services reachable from the host,
- `localhost` admin interfaces.

### The fix
New `safeGet` in `services/calendar/safe_http.go`:
- Allows only `http`/`https` schemes.
- Dials through an `http.Client` whose `net.Dialer.Control` hook **rejects any non-public resolved IP**: loopback, RFC1918 private, link-local (incl. `169.254.169.254`), unspecified, multicast, and CGNAT `100.64.0.0/10`.
- Because the check runs on the *resolved address at connect time*, it also defeats **DNS rebinding** and re-validates on **every redirect hop**.

`ICSCalendar.GetCalendarEvents` now calls `safeGet`. Added unit tests for the IP classifier and scheme rejection (both pass).

```
=== RUN   TestIsDisallowedIP            --- PASS
=== RUN   TestSafeGetRejectsNonHTTPSchemes --- PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)