### PR TITLE
fix(auth): rate-limit OTP email sending

### DIFF
--- a/server/errs/errors.go
+++ b/server/errs/errors.go
@@ -21,6 +21,7 @@ const (
 	OtpExpired            string = "otp-expired"
 	OtpInvalidCode        string = "otp-invalid-code"
 	OtpTooManyAttempts    string = "otp-too-many-attempts"
+	OtpRateLimited        string = "otp-rate-limited"
 	InvalidIdToken        string = "invalid-id-token"
 )
 

--- a/server/models/otp.go
+++ b/server/models/otp.go
@@ -12,4 +12,5 @@ type OtpCode struct {
 	Code      string             `json:"-" bson:"code"`
 	ExpiresAt time.Time          `json:"-" bson:"expiresAt"`
 	Attempts  int                `json:"-" bson:"attempts"`
+	CreatedAt time.Time          `json:"-" bson:"createdAt"`
 }

--- a/server/routes/auth.go
+++ b/server/routes/auth.go
@@ -17,6 +17,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"schej.it/server/db"
 	"schej.it/server/errs"
 	"schej.it/server/logger"
@@ -367,6 +368,22 @@ func sendOtp(c *gin.Context) {
 
 	email := strings.ToLower(strings.TrimSpace(payload.Email))
 
+	// Rate limit: refuse to send a new code if one was already sent to this
+	// email within the cooldown window. Without this, the endpoint can be
+	// abused to bomb arbitrary inboxes with OTP emails (and to enumerate
+	// accounts by timing). The 5-attempt cap on verification is unaffected.
+	const otpSendCooldown = 30 * time.Second
+	var lastOtp models.OtpCode
+	findErr := db.OtpCodesCollection.FindOne(
+		context.Background(),
+		bson.M{"email": email},
+		options.FindOne().SetSort(bson.M{"createdAt": -1}),
+	).Decode(&lastOtp)
+	if findErr == nil && time.Since(lastOtp.CreatedAt) < otpSendCooldown {
+		c.JSON(http.StatusTooManyRequests, responses.Error{Error: errs.OtpRateLimited})
+		return
+	}
+
 	// Delete any existing OTP codes for this email
 	db.OtpCodesCollection.DeleteMany(context.Background(), bson.M{"email": email})
 
@@ -376,6 +393,7 @@ func sendOtp(c *gin.Context) {
 		Code:      code,
 		ExpiresAt: time.Now().Add(10 * time.Minute),
 		Attempts:  0,
+		CreatedAt: time.Now(),
 	}
 
 	_, err := db.OtpCodesCollection.InsertOne(context.Background(), otpDoc)


### PR DESCRIPTION
## Severity: 🟡 Medium — email bombing / abuse via unauthenticated endpoint

> Stacked on #259 (→ #258 → #257).

### The problem
`/auth/otp/send` is unauthenticated and emits a fresh OTP email on every request, with no throttling. Since the target email is fully attacker-controlled, anyone can:
- **bomb any inbox** with OTP emails by replaying the request, and
- run up email-provider cost / probe the system.

The verify endpoint caps guesses at 5/code, but nothing limited *requesting* codes.

### The fix
- Add `CreatedAt` to `OtpCode`.
- `sendOtp` refuses to issue a new code if one was sent to that email within a **30-second cooldown**, returning `429 otp-rate-limited`.

Backward compatible: pre-existing codes without `createdAt` decode to the zero time and fall outside the cooldown. The per-code 5-attempt verification cap is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)