### PR TITLE
fix(security): harden analytics Basic Auth (fail-closed + constant-time)

### DIFF
--- a/server/routes/analytics.go
+++ b/server/routes/analytics.go
@@ -3,6 +3,7 @@ package routes
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"net/http"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson"
 	"schej.it/server/db"
+	"schej.it/server/logger"
 	"schej.it/server/models"
 	"schej.it/server/slackbot"
 )
@@ -21,9 +23,24 @@ func AnalyticsBasicAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		analyticsUsername := os.Getenv("ANALYTICS_USERNAME")
 		analyticsPassword := os.Getenv("ANALYTICS_PASSWORD")
+
+		// Fail closed if credentials aren't configured. Otherwise empty env
+		// vars combined with the old `user != "" || pass != ""` style check
+		// would let a request with empty credentials authenticate, exposing
+		// these admin endpoints (user lookup, manual upgrade/downgrade).
+		if analyticsUsername == "" || analyticsPassword == "" {
+			logger.StdErr.Println("ANALYTICS_USERNAME/ANALYTICS_PASSWORD not configured; refusing analytics request")
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "Analytics auth not configured"})
+			return
+		}
+
 		user, pass, hasAuth := c.Request.BasicAuth()
 
-		if !hasAuth || user != analyticsUsername || pass != analyticsPassword {
+		// Constant-time comparison to avoid leaking the credentials via timing.
+		userMatch := subtle.ConstantTimeCompare([]byte(user), []byte(analyticsUsername)) == 1
+		passMatch := subtle.ConstantTimeCompare([]byte(pass), []byte(analyticsPassword)) == 1
+
+		if !hasAuth || !userMatch || !passMatch {
 			c.Header("WWW-Authenticate", `Basic realm="Restricted"`)
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 			return


### PR DESCRIPTION
## Severity: 🟡 Medium — potential open admin API + timing side-channel

> Top of the stack — #260 → #259 → #258 → #257.

`AnalyticsBasicAuth` guards admin endpoints that can **look up any user by email** (`/analytics/user/:email`) and **manually upgrade/downgrade** accounts.

### The problems
1. **Fail-open when unconfigured.** It compared request creds directly to the env vars. If `ANALYTICS_USERNAME`/`ANALYTICS_PASSWORD` are empty/unset, a request with empty Basic Auth credentials matches → the admin API is wide open on a misconfigured deploy.
2. **Non-constant-time comparison** (`!=`) on credentials leaks information via timing.

### The fix
- **Fail closed**: return `503` if either credential env var is unset.
- Compare username & password with `crypto/subtle.ConstantTimeCompare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)